### PR TITLE
int32 to sint32

### DIFF
--- a/sitesurvey.proto
+++ b/sitesurvey.proto
@@ -9,6 +9,6 @@ message WiFiSiteSurvey {
 message AP {
     int64 mac = 1;
     string ssid = 2;
-    int32 rssi = 3;
+    sint32 rssi = 3;
     int32 channel = 4;
 }


### PR DESCRIPTION
After noticing that most of your rssi data is negative, you can change int32 to sint32. This is much more efficient to encode negative data (using zig zag encoding). Otherwise you are encoding a int32 into 10 bytes each time you have negative value. Only with this we are down to 713 bytes.