### PR TITLE
Improvements related to repeated fields packing

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -24,6 +24,7 @@ const data = jsonData.v.filter(({ mac, chan, ssid, rssi }) => {
 // We don't have to use short keys (v, chan) for the protobuf message (as in the JSON)
 // and can use full, descriptive names.
 const message = siteSurvey.create({
+  timestamp: BigInt(jsonData.ts).toString(),
   macs: data.map(({ mac }) => BigInt(`0x${mac.replace(/:/g, "")}`).toString()),
   ssids: data.map(({ ssid }) => ssid),
   rssis: data.map(({ rssi }) => rssi),
@@ -39,6 +40,7 @@ const decoded = siteSurvey.decode(encoded);
 
 console.log({
   ...decoded,
+  timestamp: BigInt(decoded.timestamp).toString(),
   macs: decoded.macs.map((mac) => formatMac(parseInt(mac, 10).toString(16))),
 });
 

--- a/sitesurvey.proto
+++ b/sitesurvey.proto
@@ -1,14 +1,11 @@
-package asset_tracker_v2;
 syntax = "proto3";
 
-message WiFiSiteSurvey {
-    uint32 timestamp = 1;
-    repeated AP accesspoints = 2;
-}
+package asset_tracker_v2;
 
-message AP {
-    int64 mac = 1;
-    string ssid = 2;
-    int32 rssi = 3;
-    int32 channel = 4;
+message WiFiSiteSurvey {
+  uint32 timestamp = 1;
+  repeated int64 macs = 2;
+  repeated string ssids = 3;
+  repeated sint32 rssis = 4;
+  repeated int32 channels = 5;
 }

--- a/sitesurvey.proto
+++ b/sitesurvey.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package asset_tracker_v2;
 
 message WiFiSiteSurvey {
-  uint32 timestamp = 1;
+  uint64 timestamp = 1;
   repeated int64 macs = 2;
   repeated string ssids = 3;
   repeated sint32 rssis = 4;


### PR DESCRIPTION
Repeated fields on complex objects (user defined, string, bytes) produce encoding overhead (repeat field id and type as many times as there are values). Furthermore, repeated field keep the order of object. Thus we can make multiple repeated fields, the rssis and channels field will be packed (no overhead) and only the ssids will have overhead. In the end, we can reconstruct objects with a zip of all the lists.