### PR TITLE
int32 to uint32

### DIFF
--- a/sitesurvey.proto
+++ b/sitesurvey.proto
@@ -10,5 +10,5 @@ message AP {
     required int64 mac = 1;
     optional string ssid = 2;
     required sint32 rssi = 3;
-    optional int32 channel = 4;
+    optional uint32 channel = 4;
 }


### PR DESCRIPTION
Since channels are always positive numbers, we can make the channel field safer by not accepting negative numbers.